### PR TITLE
Set Content-Type to application/binary when uploading files

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -179,7 +179,7 @@ Client.prototype.requestUpload = function (uri, file, callback) {
   self.options.uri = assembleUrl(self, uri);
   self.options.method = 'POST';
 
-  self.options.headers = {};
+  self.options.headers = {'Content-Type': 'application/binary'};
 
   if (useOAuth) {
     self.options.headers.Authorization = 'Bearer ' + token;


### PR DESCRIPTION
Need to explicitly set Content-Type header otherwise uploading XML
files results in a 422 error